### PR TITLE
fix: update IG profile link

### DIFF
--- a/profile/readme.md
+++ b/profile/readme.md
@@ -54,6 +54,6 @@ Also, if you would like to support us for our works you can go on our [OpenColle
 - [OpenCollective](https://opencollective.com/schrodinger-hat)
 - [Twitter](https://twitter.com/schrodinger_hat)
 - [LinkedIn](https://www.linkedin.com/company/schroedinger-hat/)
-- [Instagram](https://www.instagram.com/schrodinger_hat/)
+- [Instagram](https://www.instagram.com/schroedinger_hat/)
 
 Made with 💗


### PR DESCRIPTION
Fixed Instagram profile broken link

FYI: Instagram header link is also wrong (see the screen below)
<img width="518" alt="Screenshot 2025-03-24 at 00 16 08" src="https://github.com/user-attachments/assets/1222fd7e-371d-4fab-beef-58b2d9041af4" />
